### PR TITLE
Mark `await` as @compileTimeOnly

### DIFF
--- a/src/main/scala/scala/async/Async.scala
+++ b/src/main/scala/scala/async/Async.scala
@@ -6,6 +6,7 @@ package scala.async
 
 import scala.language.experimental.macros
 import scala.reflect.macros.Context
+import scala.reflect.internal.annotations.compileTimeOnly
 
 object Async extends AsyncBase {
 
@@ -56,8 +57,7 @@ abstract class AsyncBase {
    * @tparam T        the type of that value.
    * @return          the value.
    */
-  // TODO Replace with `@compileTimeOnly when this is implemented SI-6539
-  @deprecated("`await` must be enclosed in an `async` block", "0.1")
+  @compileTimeOnly("`await` must be enclosed in an `async` block")
   def await[T](awaitable: futureSystem.Fut[T]): T = ???
 
   protected[async] def fallbackEnabled = false

--- a/src/test/scala/scala/async/neg/NakedAwait.scala
+++ b/src/test/scala/scala/async/neg/NakedAwait.scala
@@ -13,7 +13,7 @@ import org.junit.Test
 class NakedAwait {
   @Test
   def `await only allowed in async neg`() {
-    expectError("`await` must be enclosed in an `async` block", "-deprecation -Xfatal-warnings") {
+    expectError("`await` must be enclosed in an `async` block") {
       """
         | import _root_.scala.async.Async._
         | await[Any](null)


### PR DESCRIPTION
Rather than as @deprecated.

This commit means we can no longer build against 2.10.0.

Review by @phaller
