### PR TITLE
Handle while loops as expressions in ANF transform.

### DIFF
--- a/src/test/scala/scala/async/run/ifelse0/WhileSpec.scala
+++ b/src/test/scala/scala/async/run/ifelse0/WhileSpec.scala
@@ -62,4 +62,18 @@ class WhileSpec {
     }
     result mustBe (100)
   }
+
+  @Test
+  def whileExpr() {
+    import AsyncId._
+
+    val result = async {
+      var cond = true
+      while (cond) {
+        cond = false
+        await { 22 }
+      }
+    }
+    result mustBe ()
+  }
 }


### PR DESCRIPTION
Append a `()`, as we do for `Unit` returning `if`-s and `try-s`

We don't currently support `await` in try/catch, otherwise I'd write tests for
that case, too.
