### PR TITLE
Remove left-overs of CPS fallback logic

### DIFF
--- a/src/main/scala/scala/async/internal/AsyncBase.scala
+++ b/src/main/scala/scala/async/internal/AsyncBase.scala
@@ -39,8 +39,6 @@ abstract class AsyncBase {
   @compileTimeOnly("`await` must be enclosed in an `async` block")
   def await[T](awaitable: futureSystem.Fut[T]): T = ???
 
-  protected[async] def fallbackEnabled = false
-
   def asyncImpl[T: c.WeakTypeTag](c: Context)
                                  (body: c.Expr[T])
                                  (execContext: c.Expr[futureSystem.ExecContext]): c.Expr[futureSystem.Fut[T]] = {
@@ -50,8 +48,8 @@ abstract class AsyncBase {
 
     val code = asyncMacro.asyncTransform[T](
       body.tree.asInstanceOf[asyncMacro.global.Tree],
-      execContext.tree.asInstanceOf[asyncMacro.global.Tree],
-      fallbackEnabled)(implicitly[c.WeakTypeTag[T]].asInstanceOf[asyncMacro.global.WeakTypeTag[T]]).asInstanceOf[Tree]
+      execContext.tree.asInstanceOf[asyncMacro.global.Tree]
+      )(implicitly[c.WeakTypeTag[T]].asInstanceOf[asyncMacro.global.WeakTypeTag[T]]).asInstanceOf[Tree]
 
     // Mark range positions for synthetic code as transparent to allow some wiggle room for overlapping ranges
     for (t <- code)

--- a/src/main/scala/scala/async/internal/AsyncTransform.scala
+++ b/src/main/scala/scala/async/internal/AsyncTransform.scala
@@ -7,7 +7,7 @@ trait AsyncTransform {
 
   val asyncBase: AsyncBase
 
-  def asyncTransform[T](body: Tree, execContext: Tree, cpsFallbackEnabled: Boolean)
+  def asyncTransform[T](body: Tree, execContext: Tree)
                        (resultType: WeakTypeTag[T]): Tree = {
 
     // We annotate the type of the whole expression as `T @uncheckedBounds` so as not to introduce


### PR DESCRIPTION
Completes removal performed in #37.
