### PR TITLE
Don't aggressively null out captured vars

### DIFF
--- a/src/main/scala/scala/async/internal/AsyncId.scala
+++ b/src/main/scala/scala/async/internal/AsyncId.scala
@@ -27,6 +27,9 @@ object AsyncTestLV extends AsyncBase {
   def asyncIdImpl[T: c.WeakTypeTag](c: Context)(body: c.Expr[T]): c.Expr[T] = asyncImpl[T](c)(body)(c.literalUnit)
 
   var log: List[(String, Any)] = List()
+  def assertNulledOut(a: Any): Unit = assert(log.exists(_._2 == a), AsyncTestLV.log)
+  def assertNotNulledOut(a: Any): Unit = assert(!log.exists(_._2 == a), AsyncTestLV.log)
+  def clear() = log = Nil
 
   def apply(name: String, v: Any): Unit =
     log ::= (name -> v)

--- a/src/main/scala/scala/async/internal/TransformUtils.scala
+++ b/src/main/scala/scala/async/internal/TransformUtils.scala
@@ -166,7 +166,7 @@ private[async] trait TransformUtils {
     def nestedModule(module: ModuleDef) {
     }
 
-    def nestedMethod(module: DefDef) {
+    def nestedMethod(defdef: DefDef) {
     }
 
     def byNameArgument(arg: Tree) {


### PR DESCRIPTION
Once they escape, we leave the references in the state
machines fields untouched.
