### PR TITLE
Remove unsupported Oracle JDK6 from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ scala:
   - 2.10.3
   - 2.11.0-M6
 jdk:
-  - oraclejdk6
+  - openjdk6
   - openjdk7
 notifications:
   email:


### PR DESCRIPTION
Use OpenJDK6 instead.
