### PR TITLE
Fix "not a class" crasher in live variable analysis

### DIFF
--- a/src/main/scala/scala/async/internal/LiveVariables.scala
+++ b/src/main/scala/scala/async/internal/LiveVariables.scala
@@ -55,7 +55,8 @@ trait LiveVariables {
 
     // determine which fields should be live also at the end (will not be nulled out)
     val noNull: Set[Symbol] = liftedSyms.filter { sym =>
-      tpe(sym).typeSymbol.asClass.isPrimitive || liftables.exists { tree =>
+      val typeSym = tpe(sym).typeSymbol
+      (typeSym.isClass && typeSym.asClass.isPrimitive) || liftables.exists { tree =>
         !liftedSyms.contains(tree.symbol) && tree.exists(_.symbol == sym)
       }
     }


### PR DESCRIPTION
Predicate the `asClass` cast with an `isClass` check.

Fixes #63
