### PR TITLE
Allow lazy vals without await in the initializer

### DIFF
--- a/src/main/scala/scala/async/internal/AsyncAnalysis.scala
+++ b/src/main/scala/scala/async/internal/AsyncAnalysis.scala
@@ -61,7 +61,7 @@ trait AsyncAnalysis {
         case Return(_)                                        =>
           c.abort(tree.pos, "return is illegal within a async block")
         case DefDef(mods, _, _, _, _, _) if mods.hasFlag(Flag.LAZY) && containsAwait =>
-          reportUnsupportedAwait(tree, "lazy val initalizer")
+          reportUnsupportedAwait(tree, "lazy val initializer")
         case CaseDef(_, guard, _) if guard exists isAwait     =>
           // TODO lift this restriction
           reportUnsupportedAwait(tree, "pattern guard")

--- a/src/main/scala/scala/async/internal/AsyncTransform.scala
+++ b/src/main/scala/scala/async/internal/AsyncTransform.scala
@@ -54,7 +54,7 @@ trait AsyncTransform {
       }
 
       val tryToUnit = appliedType(definitions.FunctionClass(1), futureSystemOps.tryType[Any], typeOf[Unit])
-      val template = Template(List(tryToUnit, typeOf[() => Unit]).map(TypeTree(_)), emptyValDef, body).setType(NoType)
+      val template = Template(List(tryToUnit, typeOf[() => Unit]).map(TypeTree(_)), emptyValDef, body)
 
       val t = ClassDef(NoMods, name.stateMachineT, Nil, template)
       typecheckClassDef(t)

--- a/src/test/scala/scala/async/neg/NakedAwait.scala
+++ b/src/test/scala/scala/async/neg/NakedAwait.scala
@@ -163,7 +163,7 @@ class NakedAwait {
 
   @Test
   def lazyValIllegal() {
-    expectError("await must not be used under a lazy val initalizer") {
+    expectError("await must not be used under a lazy val initializer") {
       """
         | import _root_.scala.async.internal.AsyncId._
         | def foo(): Any = async { val x = { lazy val y = await(0); y } }

--- a/src/test/scala/scala/async/run/lazyval/LazyValSpec.scala
+++ b/src/test/scala/scala/async/run/lazyval/LazyValSpec.scala
@@ -6,11 +6,6 @@ package scala.async
 package run
 package lazyval
 
-import scala.async.run.noawait
-
-import scala.async.internal.AsyncId
-import scala.async.internal.AsyncId
-import AsyncId._
 import org.junit.Test
 import scala.async.internal.AsyncId._
 


### PR DESCRIPTION
We were incorrectly typechecking the `ClassDef` of the state machine
in the macro in a way that discarded the resulting trees, and only
kept around the symbol.

The led to the the macro engine retypechecking
that node, which somehow led to duplicated lazy val initiaializer
`DefDef`-s in the template, which manifest as a `VerifyError`.

This commit:
- rescues the typechecked `ClassDef` node from the eager
  typechecking by the macro
- loosens the restriction on lazy vals in async blocks. They are
  still prohibited if they contain an await on the RHS
- Adds a test that shows evalution is indeed lazy.

Review by @phaller. I will submit a separate PR against the 2.10.x branch.
