### PR TITLE
Avoid NotImplementedError awaiting a Future[Nothing]

### DIFF
--- a/src/main/scala/scala/async/internal/Lifter.scala
+++ b/src/main/scala/scala/async/internal/Lifter.scala
@@ -113,8 +113,7 @@ trait Lifter {
             sym.setFlag(MUTABLE | STABLE | PRIVATE | LOCAL)
             sym.name = name.fresh(sym.name.toTermName)
             sym.modifyInfo(_.deconst)
-            val zeroRhs = atPos(t.pos)(gen.mkZero(vd.symbol.info))
-            treeCopy.ValDef(vd, Modifiers(sym.flags), sym.name, TypeTree(sym.tpe).setPos(t.pos), zeroRhs)
+            treeCopy.ValDef(vd, Modifiers(sym.flags), sym.name, TypeTree(sym.tpe).setPos(t.pos), EmptyTree)
           case dd@DefDef(_, _, tparams, vparamss, tpt, rhs) =>
             sym.name = this.name.fresh(sym.name.toTermName)
             sym.setFlag(PRIVATE | LOCAL)

--- a/src/test/scala/scala/async/run/toughtype/ToughType.scala
+++ b/src/test/scala/scala/async/run/toughtype/ToughType.scala
@@ -211,6 +211,22 @@ class ToughTypeSpec {
           }(SomeExecutionContext)
         }
     }
+
+  }
+
+  @Test def ticket66Nothing() {
+    import scala.concurrent.Future
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val e = new Exception()
+    val f: Future[Nothing] = Future.failed(e)
+    val f1 = async {
+      await(f)
+    }
+    try {
+      Await.result(f1, 5.seconds)
+    } catch {
+      case `e` =>
+    }
   }
 }
 


### PR DESCRIPTION
`gen.mkZero(NothingTpe)` gives the tree `Predef.???`. Instead, we should leave
 the `await` field uninitialized with `ValDef(..., rhs = EmptyTree)`.

Fixes #66
