### PR TITLE
Fix regression around type skolems and if exprs

### DIFF
--- a/src/main/scala/scala/async/internal/TransformUtils.scala
+++ b/src/main/scala/scala/async/internal/TransformUtils.scala
@@ -100,7 +100,7 @@ private[async] trait TransformUtils {
       case ld: LabelDef => ld.symbol
     }.toSet
     t.exists {
-      case rt: RefTree => !(labelDefs contains rt.symbol)
+      case rt: RefTree => rt.symbol.isLabel && !(labelDefs contains rt.symbol)
       case _ => false
     }
   }

--- a/src/test/scala/scala/async/run/ifelse4/IfElse4.scala
+++ b/src/test/scala/scala/async/run/ifelse4/IfElse4.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2012-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package scala.async
+package run
+package ifelse3
+
+import language.{reflectiveCalls, postfixOps}
+import scala.concurrent.{Future, ExecutionContext, future, Await}
+import scala.concurrent.duration._
+import scala.async.Async.{async, await}
+import org.junit.Test
+
+
+class TestIfElse4Class {
+
+  import ExecutionContext.Implicits.global
+  
+  class F[A]
+  class S[A](val id: String)
+  trait P
+ 
+  case class K(f: F[_])
+
+  def result[A](f: F[A]) = async {
+    new S[A with P]("foo")
+  }
+    
+  def run(k: K) = async {
+    val res = await(result(k.f))
+    if(true)
+      println(res)
+    res 
+  }
+}
+
+class IfElse4Spec {
+
+  @Test
+  def `await result with complex type containing skolem`() {
+    val o = new TestIfElse4Class
+    val fut = o.run(new o.K(null))
+    val res = Await.result(fut, 2 seconds)
+    res.id mustBe ("foo")
+  }
+}


### PR DESCRIPTION
Not sure what the actual cause is, but it seems to be triggered by containsForeignJumps spuriously returning true due to not checking to see if the symbol is actually a label.
