### PR TITLE
Test case for already-fixed NPE with value classes

### DIFF
--- a/src/test/scala/scala/async/run/toughtype/ToughType.scala
+++ b/src/test/scala/scala/async/run/toughtype/ToughType.scala
@@ -228,7 +228,21 @@ class ToughTypeSpec {
       case `e` =>
     }
   }
+
+  @Test def ticket83ValueClass() {
+    import scala.async.Async._
+    import scala.concurrent._, duration._, ExecutionContext.Implicits.global
+    val f = async {
+      val uid = new IntWrapper("foo")
+      await(Future(uid))
+    }
+    val result = Await.result(f, 5.seconds)
+    result mustEqual (new IntWrapper("foo"))
+  }
 }
+
+class IntWrapper(val value: String) extends AnyVal
+
 
 trait A
 


### PR DESCRIPTION
This progressed along with the fix for #66.

`TreeGen.mkZero` is a bit of a minefield: first with `Nothing` and
now with Value Classes. I wonder if we can provoke the same sort of
bug in the compiler in places where this is used.

Closes #83
