### PR TITLE
Avoid assigning null to vars of derived value type

### DIFF
--- a/src/main/scala/scala/async/internal/AsyncTransform.scala
+++ b/src/main/scala/scala/async/internal/AsyncTransform.scala
@@ -79,7 +79,7 @@ trait AsyncTransform {
           List(
             asyncBase.nullOut(global)(Expr[String](Literal(Constant(fieldSym.name.toString))), Expr[Any](Ident(fieldSym))).tree
           ),
-          Assign(gen.mkAttributedStableRef(fieldSym.owner.thisType, fieldSym), gen.mkZero(fieldSym.info))
+          Assign(gen.mkAttributedStableRef(fieldSym.owner.thisType, fieldSym), mkZero(fieldSym.info))
         )
       }
       val asyncState = asyncBlock.asyncStates.find(_.state == state).get

--- a/src/main/scala/scala/async/internal/TransformUtils.scala
+++ b/src/main/scala/scala/async/internal/TransformUtils.scala
@@ -258,6 +258,19 @@ private[async] trait TransformUtils {
     }
   }
 
+  def mkZero(tp: Type): Tree = {
+    if (tp.typeSymbol.isDerivedValueClass) {
+      val argZero = mkZero(tp.memberType(tp.typeSymbol.derivedValueClassUnbox).resultType)
+      val target: Tree = gen.mkAttributedSelect(
+        typer.typedPos(macroPos)(
+        New(TypeTree(tp.baseType(tp.typeSymbol)))), tp.typeSymbol.primaryConstructor)
+      val zero = gen.mkMethodCall(target, argZero :: Nil)
+      gen.mkCast(zero, tp)
+    } else {
+      gen.mkZero(tp)
+    }
+  }
+
   // =====================================
   // Copy/Pasted from Scala 2.10.3. See SI-7694.
   private lazy val UncheckedBoundsClass = {


### PR DESCRIPTION
`TreeGen#mkZero` returns `q"null"` for derived value classes.

```
scala> class V(val a: String) extends AnyVal
defined class V

scala> showRaw(gen.mkZero(typeOf[V]))
res0: String = Literal(Constant(null))
```

We use this API in async to generate the initial value for
ANF-lifted temporary variables.

However, this leads to NPEs, as after posterasure, we call the
unbox method on a null reference:

```
% cat sandbox/Macro.scala; scalac-hash v2.10.4 sandbox/Macro.scala; scala-hash v2.10.4 -e 'val x = Macros.myMacro'
import scala.reflect.macros.Context
import scala.language.experimental.macros

object Macros {
  def macroImpl(c: Context): c.Expr[C] = {
    import c.universe._
    val e1 = c.Expr[C](Literal(Constant(null)).setType(typeOf[C]))
    reify(e1.splice.asInstanceOf[C @annotation.unchecked.uncheckedVariance])
  }

  def myMacro: C = macro macroImpl
}

class C(val a: String) extends AnyVal
java.lang.NullPointerException
    at Main$$anon$1.<init>(scalacmd4059893593754060829.scala:1)
    at Main$.main(scalacmd4059893593754060829.scala:1)
    at Main.main(scalacmd4059893593754060829.scala)
```

This commit installs a custom version of `mkZero` that instead
returns `q"new C[$..targs](${mkZero(wrappedType)})`
