### PR TITLE
Compilation error 'A is not class' when using generic parameters in async/await fututures.

### DIFF
--- a/src/main/scala/scala/async/internal/AsyncBase.scala
+++ b/src/main/scala/scala/async/internal/AsyncBase.scala
@@ -43,7 +43,6 @@ abstract class AsyncBase {
                                  (body: c.Expr[T])
                                  (execContext: c.Expr[futureSystem.ExecContext]): c.Expr[futureSystem.Fut[T]] = {
     import c.universe._, c.internal._, decorators._
-    System.err.println("async receive:"+body)
     val asyncMacro = AsyncMacro(c, self)
 
     val code = asyncMacro.asyncTransform[T](body.tree, execContext.tree)(c.weakTypeTag[T])

--- a/src/main/scala/scala/async/internal/TransformUtils.scala
+++ b/src/main/scala/scala/async/internal/TransformUtils.scala
@@ -120,12 +120,6 @@ private[async] trait TransformUtils {
   private def isByName(fun: Tree): ((Int, Int) => Boolean) = {
     if (Boolean_ShortCircuits contains fun.symbol) (i, j) => true
     else {
-      if (fun eq null) {
-         System.err.println(s"fun == null")
-      }
-      if (fun.tpe eq null) {
-         System.err.println(s"fun.tpe == null, fun=${fun}")
-      }
       val paramss = fun.tpe.paramss
       val byNamess = paramss.map(_.map(_.asTerm.isByNameParam))
       (i, j) => util.Try(byNamess(i)(j)).getOrElse(false)
@@ -337,7 +331,7 @@ private[async] trait TransformUtils {
     (cls.info.decls.find(sym => sym.isMethod && sym.asTerm.isParamAccessor) getOrElse NoSymbol)
 
   def mkZero(tp: Type): Tree = {
-    if (tp.typeSymbol.asClass.isDerivedValueClass) {
+    if (tp.typeSymbol.isClass && tp.typeSymbol.asClass.isDerivedValueClass) {
       val argZero = mkZero(derivedValueClassUnbox(tp.typeSymbol).infoIn(tp).resultType)
       val baseType = tp.baseType(tp.typeSymbol) // use base type here to dealias / strip phantom "tagged types" etc.
 

--- a/src/test/scala/scala/async/run/gen0/AsyncSpec.scala
+++ b/src/test/scala/scala/async/run/gen0/AsyncSpec.scala
@@ -8,10 +8,27 @@ import scala.concurrent.duration._
 import scala.async.Async.{async, await}
 import org.junit.Test
 
+class TestS[A](a:A)
+{
 
-class Test1Class {
+  def awrite(v:A): Future[A] =
+      Future successful v
+
+  def aread: Future[A] =
+      Future successful a
+
+}
+
+class Test1GenAsyncOp[A] {
 
   import ExecutionContext.Implicits.global
+
+  def testfun[A](a1:A,a2:A): Future[Boolean] = async {
+       val ts = new TestS(a1)
+       val s1 = await(ts.awrite(a2))
+       val s2 = await(ts.aread)
+       s1 == s2
+  }
 
 }
 
@@ -19,14 +36,11 @@ class Test1Class {
 class AsyncSpec {
 
   @Test
-  def `generic`() {
-   /*
-    val o = new Test1Class
-    val fut = o.m2(10)
-    val res = Await.result(fut, 2 seconds)
-    res mustBe (14)
-   */
-    1 mustBe (1)
+  def `operation with futures generic`() {
+    val op = new Test1GenAsyncOp[Int]
+    val f = op.testfun(1,2)
+    val res = Await.result(f, 2 seconds)
+    res mustBe (false)
   }
 
 }


### PR DESCRIPTION
...n futures inside async blocks.
