### PR TITLE
Fix regression around await of non-class type

### DIFF
--- a/src/main/scala/scala/async/internal/TransformUtils.scala
+++ b/src/main/scala/scala/async/internal/TransformUtils.scala
@@ -331,9 +331,10 @@ private[async] trait TransformUtils {
     (cls.info.decls.find(sym => sym.isMethod && sym.asTerm.isParamAccessor) getOrElse NoSymbol)
 
   def mkZero(tp: Type): Tree = {
-    if (tp.typeSymbol.asClass.isDerivedValueClass) {
-      val argZero = mkZero(derivedValueClassUnbox(tp.typeSymbol).infoIn(tp).resultType)
-      val baseType = tp.baseType(tp.typeSymbol) // use base type here to dealias / strip phantom "tagged types" etc.
+    val tpSym = tp.typeSymbol
+    if (tpSym.isClass && tpSym.asClass.isDerivedValueClass) {
+      val argZero = mkZero(derivedValueClassUnbox(tpSym).infoIn(tp).resultType)
+      val baseType = tp.baseType(tpSym) // use base type here to dealias / strip phantom "tagged types" etc.
 
       // By explicitly attributing the types and symbols here, we subvert privacy.
       // Otherwise, ticket86PrivateValueClass would fail.
@@ -342,7 +343,7 @@ private[async] trait TransformUtils {
       // q"new ${valueClass}[$..targs](argZero)"
       val target: Tree = gen.mkAttributedSelect(
         c.typecheck(atMacroPos(
-        New(TypeTree(baseType)))), tp.typeSymbol.asClass.primaryConstructor)
+        New(TypeTree(baseType)))), tpSym.asClass.primaryConstructor)
 
       val zero = gen.mkMethodCall(target, argZero :: Nil)
 

--- a/src/test/scala/scala/async/run/toughtype/ToughType.scala
+++ b/src/test/scala/scala/async/run/toughtype/ToughType.scala
@@ -304,6 +304,21 @@ class ToughTypeSpec {
     val result = Await.result(fut, 5.seconds)
     result mustBe None
   }
+
+  @Test def awaitOfAbstractType(): Unit = {
+    import ExecutionContext.Implicits.global
+
+    def combine[A](a1: A, a2: A): A = a1
+
+    def combineAsync[A](a1: Future[A], a2: Future[A]) = async {
+      combine(await(a1), await(a2))
+    }
+
+    val fut = combineAsync(Future(1), Future(2))
+
+    val result = Await.result(fut, 5.seconds)
+    result mustEqual 1
+  }
 }
 
 class IntWrapper(val value: String) extends AnyVal {


### PR DESCRIPTION
E.g. type param, abstract type.

The test case in the PR:

``` scala
def combine[A](a1: A, a2: A): A = a1

def combineAsync[A](a1: Future[A], a2: Future[A]) = async {
  combine(await(a1), await(a2))
}
```

fails with the following exception:

```
[error] /Users/gnovark/git/async/src/test/scala/scala/async/run/toughtype/ToughType.scala:313: exception during macro expansion: 
[error] scala.ScalaReflectionException: type A is not a class
[error]     at scala.reflect.api.Symbols$SymbolApi$class.asClass(Symbols.scala:272)
[error]     at scala.reflect.internal.Symbols$SymbolContextApiImpl.asClass(Symbols.scala:82)
[error]     at scala.async.internal.TransformUtils$class.mkZero(TransformUtils.scala:334)
[error]     at scala.async.internal.AsyncMacro$$anon$1.mkZero(AsyncMacro.scala:6)
```
