### PR TITLE
fix Scala version number handling for 2.13 community build

### DIFF
--- a/src/test/scala/scala/async/package.scala
+++ b/src/test/scala/scala/async/package.scala
@@ -64,7 +64,7 @@ package object async {
   }
 
   def scalaBinaryVersion: String = {
-    val PreReleasePattern = """.*-(M|RC).*""".r
+    val PreReleasePattern = """.*-(M|RC|pre-).*""".r
     val Pattern = """(\d+\.\d+)\..*""".r
     val SnapshotPattern = """(\d+\.\d+\.\d+)-\d+-\d+-.*""".r
     scala.util.Properties.versionNumberString match {


### PR DESCRIPTION
we need to handle a Scala version like `2.13.0-pre-5e84129`,
as we see in nightly builds before bincompat is locked down