### PR TITLE
Performance improvements to the macro

### DIFF
--- a/src/main/scala/scala/async/internal/AnfTransform.scala
+++ b/src/main/scala/scala/async/internal/AnfTransform.scala
@@ -163,13 +163,13 @@ private[async] trait AnfTransform {
           }
         }
 
-        def defineVar(prefix: String, tp: Type, pos: Position): ValDef = {
+        def defineVar(prefix: TermName, tp: Type, pos: Position): ValDef = {
           val sym = api.currentOwner.newTermSymbol(name.fresh(prefix), pos, MUTABLE | SYNTHETIC).setInfo(uncheckedBounds(tp))
           valDef(sym, mkZero(uncheckedBounds(tp))).setType(NoType).setPos(pos)
         }
       }
 
-      def defineVal(prefix: String, lhs: Tree, pos: Position): ValDef = {
+      def defineVal(prefix: TermName, lhs: Tree, pos: Position): ValDef = {
         val sym = api.currentOwner.newTermSymbol(name.fresh(prefix), pos, SYNTHETIC).setInfo(uncheckedBounds(lhs.tpe))
         internal.valDef(sym, internal.changeOwner(lhs, api.currentOwner, sym)).setType(NoType).setPos(pos)
       }

--- a/src/main/scala/scala/async/internal/AsyncMacro.scala
+++ b/src/main/scala/scala/async/internal/AsyncMacro.scala
@@ -3,8 +3,18 @@ package scala.async.internal
 object AsyncMacro {
   def apply(c0: reflect.macros.Context, base: AsyncBase)(body0: c0.Tree): AsyncMacro { val c: c0.type } = {
     import language.reflectiveCalls
+
+    // Use an attachment on RootClass as a sneaky place for a per-Global cache
+    val att = c0.internal.attachments(c0.universe.rootMirror.RootClass)
+    val names = att.get[AsyncNames[_]].getOrElse {
+      val names = new AsyncNames[c0.universe.type](c0.universe)
+      att.update(names)
+      names
+    }
+
     new AsyncMacro { self =>
       val c: c0.type                                             = c0
+      val asyncNames: AsyncNames[c.universe.type]                = names.asInstanceOf[AsyncNames[c.universe.type]]
       val body: c.Tree = body0
       // This member is required by `AsyncTransform`:
       val asyncBase: AsyncBase                                   = base
@@ -23,6 +33,7 @@ private[async] trait AsyncMacro
   val c: scala.reflect.macros.Context
   val body: c.Tree
   var containsAwait: c.Tree => Boolean
+  val asyncNames: AsyncNames[c.universe.type]
 
   lazy val macroPos: c.universe.Position = c.macroApplication.pos.makeTransparent
   def atMacroPos(t: c.Tree): c.Tree = c.universe.atPos(macroPos)(t)

--- a/src/main/scala/scala/async/internal/AsyncNames.scala
+++ b/src/main/scala/scala/async/internal/AsyncNames.scala
@@ -1,0 +1,109 @@
+package scala.async.internal
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.api.Names
+
+/**
+  * A per-global cache of names needed by the Async macro.
+  */
+final class AsyncNames[U <: Names with Singleton](val u: U) {
+  self =>
+  import u._
+
+  abstract class NameCache[N <: U#Name](base: String) {
+    val cached = new ArrayBuffer[N]()
+    protected def newName(s: String): N
+    def apply(i: Int): N = {
+      if (cached.isDefinedAt(i)) cached(i)
+      else {
+        assert(cached.length == i)
+        val name = newName(freshenString(base, i))
+        cached += name
+        name
+      }
+    }
+  }
+
+  final class TermNameCache(base: String) extends NameCache[U#TermName](base) {
+    override protected def newName(s: String): U#TermName = newTermName(s)
+  }
+  final class TypeNameCache(base: String) extends NameCache[U#TypeName](base) {
+    override protected def newName(s: String): U#TypeName = newTypeName(s)
+  }
+  private val matchRes: TermNameCache = new TermNameCache("match")
+  private val ifRes: TermNameCache = new TermNameCache("if")
+  private val await: TermNameCache = new TermNameCache("await")
+
+  private val resume = newTermName("resume")
+  private val completed: TermName = newTermName("completed$async")
+  private val apply = newTermName("apply")
+  private val stateMachine  = newTermName("stateMachine$async")
+  private val stateMachineT = stateMachine.toTypeName
+  private val state: u.TermName = newTermName("state$async")
+  private val execContext = newTermName("execContext$async")
+  private val tr: u.TermName = newTermName("tr$async")
+  private val t: u.TermName = newTermName("throwable$async")
+
+  final class NameSource[N <: U#Name](cache: NameCache[N]) {
+    private val count = new AtomicInteger(0)
+    def apply(): N = cache(count.getAndIncrement())
+  }
+
+  class AsyncName {
+    final val matchRes = new NameSource[U#TermName](self.matchRes)
+    final val ifRes = new NameSource[U#TermName](self.matchRes)
+    final val await = new NameSource[U#TermName](self.await)
+    final val completed = self.completed
+    final val result = self.resume
+    final val apply = self.apply
+    final val stateMachine = self.stateMachine
+    final val stateMachineT = self.stateMachineT
+    final val state: u.TermName = self.state
+    final val execContext = self.execContext
+    final val tr: u.TermName = self.tr
+    final val t: u.TermName = self.t
+
+    private val seenPrefixes = mutable.AnyRefMap[Name, AtomicInteger]()
+    private val freshened = mutable.HashSet[Name]()
+
+    final def freshenIfNeeded(name: TermName): TermName = {
+      seenPrefixes.getOrNull(name) match {
+        case null =>
+          seenPrefixes.put(name, new AtomicInteger())
+          name
+        case counter =>
+          freshen(name, counter)
+      }
+    }
+    final def freshenIfNeeded(name: TypeName): TypeName = {
+      seenPrefixes.getOrNull(name) match {
+        case null =>
+          seenPrefixes.put(name, new AtomicInteger())
+          name
+        case counter =>
+          freshen(name, counter)
+      }
+    }
+    final def freshen(name: TermName): TermName = {
+      val counter = seenPrefixes.getOrElseUpdate(name, new AtomicInteger())
+      freshen(name, counter)
+    }
+    final def freshen(name: TypeName): TypeName = {
+      val counter = seenPrefixes.getOrElseUpdate(name, new AtomicInteger())
+      freshen(name, counter)
+    }
+    private def freshen(name: TermName, counter: AtomicInteger): TermName = {
+      if (freshened.contains(name)) name
+      else TermName(freshenString(name.toString, counter.incrementAndGet()))
+    }
+    private def freshen(name: TypeName, counter: AtomicInteger): TypeName = {
+      if (freshened.contains(name)) name
+      else TypeName(freshenString(name.toString, counter.incrementAndGet()))
+    }
+  }
+
+  private def freshenString(name: String, counter: Int): String = name.toString + "$async$" + counter
+}

--- a/src/main/scala/scala/async/internal/AsyncNames.scala
+++ b/src/main/scala/scala/async/internal/AsyncNames.scala
@@ -37,7 +37,7 @@ final class AsyncNames[U <: Names with Singleton](val u: U) {
   private val ifRes: TermNameCache = new TermNameCache("if")
   private val await: TermNameCache = new TermNameCache("await")
 
-  private val resume = newTermName("resume")
+  private val result = newTermName("result$async")
   private val completed: TermName = newTermName("completed$async")
   private val apply = newTermName("apply")
   private val stateMachine  = newTermName("stateMachine$async")
@@ -57,7 +57,7 @@ final class AsyncNames[U <: Names with Singleton](val u: U) {
     final val ifRes = new NameSource[U#TermName](self.matchRes)
     final val await = new NameSource[U#TermName](self.await)
     final val completed = self.completed
-    final val result = self.resume
+    final val result = self.result
     final val apply = self.apply
     final val stateMachine = self.stateMachine
     final val stateMachineT = self.stateMachineT

--- a/src/main/scala/scala/async/internal/AsyncTransform.scala
+++ b/src/main/scala/scala/async/internal/AsyncTransform.scala
@@ -70,9 +70,6 @@ trait AsyncTransform {
       buildAsyncBlock(anfTree, symLookup)
     }
 
-    if(AsyncUtils.verbose)
-      logDiagnostics(anfTree, asyncBlock.asyncStates.map(_.toString))
-
     val liftedFields: List[Tree] = liftables(asyncBlock.asyncStates)
 
     // live variables analysis
@@ -114,10 +111,14 @@ trait AsyncTransform {
       futureSystemOps.spawn(body, execContext) // generate lean code for the simple case of `async { 1 + 1 }`
     else
       startStateMachine
+
+    if(AsyncUtils.verbose) {
+      logDiagnostics(anfTree, asyncBlock, asyncBlock.asyncStates.map(_.toString))
+    }
     cleanupContainsAwaitAttachments(result)
   }
 
-  def logDiagnostics(anfTree: Tree, states: Seq[String]): Unit = {
+  def logDiagnostics(anfTree: Tree, block: AsyncBlock, states: Seq[String]): Unit = {
     def location = try {
       macroPos.source.path
     } catch {
@@ -129,6 +130,8 @@ trait AsyncTransform {
     AsyncUtils.vprintln(s"${c.macroApplication}")
     AsyncUtils.vprintln(s"ANF transform expands to:\n $anfTree")
     states foreach (s => AsyncUtils.vprintln(s))
+    AsyncUtils.vprintln("===== DOT =====")
+    AsyncUtils.vprintln(block.toDot)
   }
 
   /**

--- a/src/main/scala/scala/async/internal/AsyncTransform.scala
+++ b/src/main/scala/scala/async/internal/AsyncTransform.scala
@@ -115,6 +115,7 @@ trait AsyncTransform {
     if(AsyncUtils.verbose) {
       logDiagnostics(anfTree, asyncBlock, asyncBlock.asyncStates.map(_.toString))
     }
+    futureSystemOps.dot(enclosingOwner, body).foreach(f => f(asyncBlock.toDot))
     cleanupContainsAwaitAttachments(result)
   }
 

--- a/src/main/scala/scala/async/internal/ExprBuilder.scala
+++ b/src/main/scala/scala/async/internal/ExprBuilder.scala
@@ -95,7 +95,7 @@ trait ExprBuilder {
         c.Expr[futureSystem.Tryy[Any] => Unit](fun), c.Expr[futureSystem.ExecContext](Ident(name.execContext))).tree
       val tryGetOrCallOnComplete: List[Tree] =
         if (futureSystemOps.continueCompletedFutureOnSameThread) {
-          val tempName = name.fresh(name.completed)
+          val tempName = name.completed
           val initTemp = ValDef(NoMods, tempName, TypeTree(futureSystemOps.tryType[Any]), futureSystemOps.getCompleted[Any](c.Expr[futureSystem.Fut[Any]](awaitable.expr)).tree)
           val ifTree = If(Apply(Select(Literal(Constant(null)), TermName("ne")), Ident(tempName) :: Nil),
             adaptToUnit(ifIsFailureTree[T](Ident(tempName)) :: Nil),
@@ -520,7 +520,7 @@ trait ExprBuilder {
   }
 
   private def isSyntheticBindVal(tree: Tree) = tree match {
-    case vd@ValDef(_, lname, _, Ident(rname)) => lname.toString.contains(name.bindSuffix)
+    case vd@ValDef(_, lname, _, Ident(rname)) => attachments(vd.symbol).contains[SyntheticBindVal.type]
     case _                                    => false
   }
 

--- a/src/main/scala/scala/async/internal/FutureSystem.scala
+++ b/src/main/scala/scala/async/internal/FutureSystem.scala
@@ -75,6 +75,7 @@ trait FutureSystem {
 
   def mkOps(c0: Context): Ops { val c: c0.type }
 
+  @deprecated("No longer honoured by the macro, all generated names now contain $async to avoid accidental clashes with lambda lifted names", "0.9.7")
   def freshenAllNames: Boolean = false
   def emitTryCatch: Boolean = true
   def resultFieldName: String = "result"

--- a/src/main/scala/scala/async/internal/FutureSystem.scala
+++ b/src/main/scala/scala/async/internal/FutureSystem.scala
@@ -81,6 +81,7 @@ trait FutureSystem {
   @deprecated("No longer honoured by the macro, all generated names now contain $async to avoid accidental clashes with lambda lifted names", "0.9.7")
   def freshenAllNames: Boolean = false
   def emitTryCatch: Boolean = true
+  @deprecated("No longer honoured by the macro, all generated names now contain $async to avoid accidental clashes with lambda lifted names", "0.9.7")
   def resultFieldName: String = "result"
 }
 

--- a/src/main/scala/scala/async/internal/FutureSystem.scala
+++ b/src/main/scala/scala/async/internal/FutureSystem.scala
@@ -71,6 +71,9 @@ trait FutureSystem {
 
     /** A hook for custom macros to transform the tree post-ANF transform */
     def postAnfTransform(tree: Block): Block = tree
+
+    /** A hook for custom macros to selectively generate and process a Graphviz visualization of the transformed state machine */
+    def dot(enclosingOwner: Symbol, macroApplication: Tree): Option[(String => Unit)] = None
   }
 
   def mkOps(c0: Context): Ops { val c: c0.type }

--- a/src/main/scala/scala/async/internal/Lifter.scala
+++ b/src/main/scala/scala/async/internal/Lifter.scala
@@ -120,13 +120,13 @@ trait Lifter {
             val rhs1 = if (sym.asTerm.isLazy) rhs else EmptyTree
             treeCopy.ValDef(vd, Modifiers(sym.flags), sym.name, TypeTree(tpe(sym)).setPos(t.pos), rhs1)
           case dd@DefDef(_, _, tparams, vparamss, tpt, rhs) =>
-            sym.setName(this.name.fresh(sym.name.toTermName))
+            sym.setName(this.name.freshen(sym.name.toTermName))
             sym.setFlag(PRIVATE | LOCAL)
             // Was `DefDef(sym, rhs)`, but this ran afoul of `ToughTypeSpec.nestedMethodWithInconsistencyTreeAndInfoParamSymbols`
             // due to the handling of type parameter skolems in `thisMethodType` in `Namers`
             treeCopy.DefDef(dd, Modifiers(sym.flags), sym.name, tparams, vparamss, tpt, rhs)
           case cd@ClassDef(_, _, tparams, impl)             =>
-            sym.setName(newTypeName(name.fresh(sym.name.toString).toString))
+            sym.setName(name.freshen(sym.name.toTypeName))
             companionship.companionOf(cd.symbol) match {
               case NoSymbol     =>
               case moduleSymbol =>
@@ -137,13 +137,13 @@ trait Lifter {
           case md@ModuleDef(_, _, impl)                     =>
             companionship.companionOf(md.symbol) match {
               case NoSymbol    =>
-                sym.setName(name.fresh(sym.name.toTermName))
+                sym.setName(name.freshen(sym.name.toTermName))
                 sym.asModule.moduleClass.setName(sym.name.toTypeName)
               case classSymbol => // will be renamed by `case ClassDef` above.
             }
             treeCopy.ModuleDef(md, Modifiers(sym.flags), sym.name, impl)
           case td@TypeDef(_, _, tparams, rhs)               =>
-            sym.setName(newTypeName(name.fresh(sym.name.toString).toString))
+            sym.setName(name.freshen(sym.name.toTypeName))
             treeCopy.TypeDef(td, Modifiers(sym.flags), sym.name, tparams, rhs)
         }
         atPos(t.pos)(treeLifted)

--- a/src/main/scala/scala/async/internal/StateSet.scala
+++ b/src/main/scala/scala/async/internal/StateSet.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+package scala.async.internal
+
+import java.util
+import java.util.function.{Consumer, IntConsumer}
+
+import scala.collection.JavaConverters.{asScalaIteratorConverter, iterableAsScalaIterableConverter}
+import scala.collection.mutable
+
+// Set for StateIds, which are either small positive integers or -symbolID.
+final class StateSet {
+  private var bitSet = new java.util.BitSet()
+  private var caseSet = new util.HashSet[Integer]()
+  def +=(stateId: Int): Unit = if (stateId > 0) bitSet.set(stateId) else caseSet.add(stateId)
+  def contains(stateId: Int): Boolean = if (stateId > 0 && stateId < 1024) bitSet.get(stateId) else caseSet.contains(stateId)
+  def iterator: Iterator[Integer] = {
+    bitSet.stream().iterator().asScala ++ caseSet.asScala.iterator
+  }
+  def foreach(f: IntConsumer): Unit = {
+    bitSet.stream().forEach(f)
+    caseSet.stream().forEach(new Consumer[Integer] {
+      override def accept(value: Integer): Unit = f.accept(value)
+    })
+  }
+}

--- a/src/main/scala/scala/async/internal/TransformUtils.scala
+++ b/src/main/scala/scala/async/internal/TransformUtils.scala
@@ -17,42 +17,8 @@ private[async] trait TransformUtils {
   import c.internal._
   import decorators._
 
-  private object baseNames {
-
-    val matchRes = "matchres"
-    val ifRes = "ifres"
-    val bindSuffix = "$bind"
-    val completed = newTermName("completed")
-
-    val state = newTermName("state")
-    val result = newTermName(self.futureSystem.resultFieldName)
-    val execContext = newTermName("execContext")
-    val tr = newTermName("tr")
-    val t = newTermName("throwable")
-  }
-  
-  object name {
-    val matchRes      = newTermName(baseNames.matchRes)
-    val ifRes         = newTermName(baseNames.ifRes)
-    def bindSuffix    = baseNames.bindSuffix
-    def completed     = baseNames.completed
-
-    val state         = maybeFresh(baseNames.state)
-    val result        = baseNames.result
-    val execContext   = maybeFresh(baseNames.execContext)
-    val tr            = maybeFresh(baseNames.tr)
-    val t             = maybeFresh(baseNames.t)
-
-    val await = newTermName("await")
-    val resume = newTermName("resume")
-    val apply = newTermName("apply")
-    val stateMachine  = newTermName(fresh("stateMachine"))
-    val stateMachineT = stateMachine.toTypeName
-
-    def maybeFresh(name: TermName): TermName = if (self.asyncBase.futureSystem.freshenAllNames) fresh(name) else name
-    def maybeFresh(name: String): String = if (self.asyncBase.futureSystem.freshenAllNames) fresh(name) else name
-    def fresh(name: TermName): TermName = c.freshName(name)
-
+  object name extends asyncNames.AsyncName {
+    def fresh(name: TermName): TermName = freshenIfNeeded(name)
     def fresh(name: String): String = c.freshName(name)
   }
 

--- a/src/test/scala/scala/async/run/anf/AnfTransformSpec.scala
+++ b/src/test/scala/scala/async/run/anf/AnfTransformSpec.scala
@@ -403,7 +403,8 @@ class AnfTransformSpec {
       """.stripMargin
     })
     val applyImplicitView = tree.collect { case x if x.getClass.getName.endsWith("ApplyImplicitView") => x }
-    applyImplicitView.map(_.toString) mustStartWith List("view(a$macro$")
+    println(applyImplicitView)
+    applyImplicitView.map(_.toString) mustStartWith List("view(")
   }
 
   @Test


### PR DESCRIPTION
## Avoid boxing

Don't box state IDs in collections.

## Avoid needless string to name conversion

  - Introduce a per-Global store of names
  - Avoid double freshening names
  - Use $async$ in all names to avoid clashes with, e.g. lambda lifted methods.

## Rework dead state elimination to happen as part of expr builder

If we're in the expr position of a block, the nested state
generation can reuse the successor state.

Also, output .dot graph of state machine in verbose mode.

Sample: https://gist.github.com/88225478b11c118609b9348d61e13630

View with a local Graphviz install or http://graphviz.it/#/gallery/unix.gv

Sample generated from late expansion of:

    val result = run(
      """
        import scala.async.run.late.{autoawait,lateasync}
        case class FixedFoo(foo: Int)
        class Foobar(val foo: Int, val bar: Double) {
          def guard: Boolean = true
          @autoawait @lateasync def getValue = 4.2
          @autoawait @lateasync def func(f: Any) = {
            ("": Any) match {
              case (x1, y1) if guard => x1.toString; y1.toString
              case (x2, y2) if guard => x2.toString; y2.toString
              case (x3, y3) if guard => x3.toString; y3.toString
              case (x4, y4) =>
                 getValue; x4.toString; y4.toString
            }
          }
        }
        object Test {
          @lateasync def test() = new Foobar(0, 0).func(4)
        }
        """)