### PR TITLE
Try to add 2.13.0-M5 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ scalaModuleSettings
 
 scalaVersionsByJvm in ThisBuild := {
   val v212 = "2.12.6"
-  val v213 = "2.13.0-M3"
+  val v213 = "2.13.0-M5"
 
   val allFalse = List(v212 -> false, v213 -> false)
   Map(

--- a/src/main/scala/scala/async/internal/LiveVariables.scala
+++ b/src/main/scala/scala/async/internal/LiveVariables.scala
@@ -185,7 +185,7 @@ trait LiveVariables {
      */
 
     var LVentry = IntMap[Set[Symbol]]() withDefaultValue Set[Symbol]()
-    var LVexit  = IntMap[Set[Symbol]]() withDefaultValue Set[Symbol]()
+    var LVexit: Map[Int, Set[Symbol]] = IntMap[Set[Symbol]]() withDefaultValue Set[Symbol]()
 
     // All fields are declared to be dead at the exit of the final async state, except for the ones
     // that cannot be nulled out at all (those in noNull), because they have been captured by a nested def.

--- a/src/test/scala/scala/async/run/futures/FutureSpec.scala
+++ b/src/test/scala/scala/async/run/futures/FutureSpec.scala
@@ -6,8 +6,9 @@ package scala.async
 package run
 package futures
 
-import scala.language.postfixOps
+import java.util.concurrent.ConcurrentHashMap
 
+import scala.language.postfixOps
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.concurrent.duration.Duration.Inf
@@ -34,10 +35,10 @@ class FutureSpec {
   /* future specification */
 
     @Test def `A future with custom ExecutionContext should handle Throwables`(): Unit = {
-      val ms = new mutable.HashSet[Throwable] with mutable.SynchronizedSet[Throwable]
+      val ms = new ConcurrentHashMap[Throwable, Unit]
       implicit val ec = scala.concurrent.ExecutionContext.fromExecutor(new java.util.concurrent.ForkJoinPool(), {
         t =>
-        ms += t
+        ms.put(t, ())
       })
       
       class ThrowableTest(m: String) extends Throwable(m)


### PR DESCRIPTION
Opening this if this can be of any help… two tests still fail:
```
$ sbt ++2.13.0-M5 test
[…]
[error] Test scala.async.run.futures.FutureSpec.A future with custom ExecutionContext should handle Throwables failed: assertion failed: 0 is not 4, took 1.01 sec
[error] Test scala.async.run.futures.FutureSpec.support pattern matching within a for-comprehension failed: scala.concurrent.Future$$anon$2: Future.filter predicate is not satisfied, took 0.019 sec
[error] Failed: Total 180, Failed 2, Errors 0, Passed 178
[error] Failed tests:
[error] 	scala.async.run.futures.FutureSpec
[error] (test:test) sbt.TestsFailedException: Tests unsuccessful
```