### PR TITLE
Macros require explicit return type

### DIFF
--- a/src/main/scala/scala/async/internal/AsyncId.scala
+++ b/src/main/scala/scala/async/internal/AsyncId.scala
@@ -12,7 +12,7 @@ object AsyncId extends AsyncBase {
   lazy val futureSystem = IdentityFutureSystem
   type FS = IdentityFutureSystem.type
 
-  def async[T](body: => T) = macro asyncIdImpl[T]
+  def async[T](body: => T): T = macro asyncIdImpl[T]
 
   def asyncIdImpl[T: c.WeakTypeTag](c: Context)(body: c.Expr[T]): c.Expr[T] = asyncImpl[T](c)(body)(c.literalUnit)
 }
@@ -21,7 +21,7 @@ object AsyncTestLV extends AsyncBase {
   lazy val futureSystem = IdentityFutureSystem
   type FS = IdentityFutureSystem.type
 
-  def async[T](body: T) = macro asyncIdImpl[T]
+  def async[T](body: T): T = macro asyncIdImpl[T]
 
   def asyncIdImpl[T: c.WeakTypeTag](c: Context)(body: c.Expr[T]): c.Expr[T] = asyncImpl[T](c)(body)(c.literalUnit)
 


### PR DESCRIPTION
Visible on the community build.

https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/1714/consoleFull