### PR TITLE
Fix ownership corruption problem in the awaited expression

### DIFF
--- a/src/main/scala/scala/async/internal/AnfTransform.scala
+++ b/src/main/scala/scala/async/internal/AnfTransform.scala
@@ -255,7 +255,7 @@ private[async] trait AnfTransform {
 
             case ValDef(mods, name, tpt, rhs) =>
               if (containsAwait(rhs)) {
-                val stats :+ expr = api.atOwner(api.currentOwner.owner)(linearize.transformToList(rhs))
+                val stats :+ expr = linearize.transformToList(rhs)
                 stats.foreach(_.changeOwner(api.currentOwner, api.currentOwner.owner))
                 stats :+ treeCopy.ValDef(tree, mods, name, tpt, expr)
               } else List(tree)


### PR DESCRIPTION
Previously, `whyDoYouHateMe` was incorrectly owned by `jerk`,
rather than `pointlessSymbolOwner` after the ANF transform,
which in turn led to:

```
java.util.NoSuchElementException: value whyDoHateMe
    at scala.collection.mutable.AnyRefMap$ExceptionDefault.apply(AnyRefMap.scala:425)
    at scala.collection.mutable.AnyRefMap$ExceptionDefault.apply(AnyRefMap.scala:424)
    at scala.collection.mutable.AnyRefMap.apply(AnyRefMap.scala:180)
    at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder$locals$.load(BCodeSkelBuilder.scala:390)
    at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:354)
```