### PR TITLE
Cross compile for Scala.js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,27 @@
-ScalaModulePlugin.scalaModuleSettings
-ScalaModulePlugin.scalaModuleOsgiSettings
 
-name := "scala-async"
-scalaModuleAutomaticModuleName := Some("scala.async")
+val sharedSettings = ScalaModulePlugin.scalaModuleSettings ++ ScalaModulePlugin.scalaModuleOsgiSettings ++ Seq(
+  name := "scala-async",
+  scalaModuleAutomaticModuleName := Some("scala.async"),
 
-libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided"
-libraryDependencies += "junit" % "junit" % "4.13.2" % Test
-libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
+  OsgiKeys.exportPackage := Seq(s"scala.async.*;version=${version.value}"),
 
-ScalaModulePlugin.enableOptimizer
-testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s")
-Test / scalacOptions ++= Seq("-Yrangepos")
-scalacOptions ++= List("-deprecation" , "-Xasync")
+  libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
+  libraryDependencies += "junit" % "junit" % "4.13.2" % Test,
+  libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
+
+  ScalaModulePlugin.enableOptimizer,
+  testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s"),
+  Test / scalacOptions ++= Seq("-Yrangepos"),
+  scalacOptions ++= List("-deprecation" , "-Xasync")
+)
+
+lazy val proj = crossProject(JSPlatform, JVMPlatform)
+  .withoutSuffixFor(JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("."))
+  .settings(sharedSettings)
+
+lazy val root = project.in(file(".")).settings(sharedSettings)
 
 Global / parallelExecution := false
 
@@ -41,7 +51,6 @@ pomExtra := (
     </developer>
   </developers>
   )
-OsgiKeys.exportPackage := Seq(s"scala.async.*;version=${version.value}")
 
 commands += testDeterminism
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "2.3.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")


### PR DESCRIPTION
PR for #248 

The project cross compiles without any changes, it was only necessary to create a cross project in SBT.

In current configuration project `projJS` can be used to compile / publish Scala.js artifacts, e.g. `projJS/publishLocal`. I have verified against my own project the artifacts obtained this way work with both compile and fastOptJS.

I have no idea what other steps needs to be taken to get this final and published.

If any more changes are necessary from me, feel free to write.